### PR TITLE
Fixes for SDK Migration

### DIFF
--- a/src/Workbench.jsx
+++ b/src/Workbench.jsx
@@ -426,7 +426,7 @@ const WorkBench = ({ stytch, stytchUser }) => {
 
     for (const wr of stytchUser.webauthn_registrations) {
       const onClick = () => {
-        dispatch(stytch.user.deleteWebauthn(wr.webauthn_registration_id));
+        dispatch(stytch.user.deleteWebauthnRegistration(wr.webauthn_registration_id));
       };
       userFactorControls.push(
         <Button
@@ -435,6 +435,16 @@ const WorkBench = ({ stytch, stytchUser }) => {
           onClick={onClick}
         />,
         <br key={`brk-${wr.webauthn_registration_id}`} />
+      );
+    }
+
+    for (const totp of stytchUser.totps) {
+      const onClick = () => {
+        dispatch(stytch.user.deleteTOTP(totp.totp_id));
+      };
+      userFactorControls.push(
+        <Button key={`btn-${totp.totp_id}`} name={`Delete TOTP: ${totp.totp_id}`} onClick={onClick} />,
+        <br key={`brk-${totp.totp_id}`} />,
       );
     }
   }

--- a/src/Workbench.jsx
+++ b/src/Workbench.jsx
@@ -37,9 +37,6 @@ const WorkBench = ({ stytch, stytchUser }) => {
   const passwordRef = useRef();
   const newPasswordRef = useRef();
 
-  const [wrCredCreateOpts, setCredCreateOpts] = useState(null);
-  const [wrCredRequestOpts, setCredRequestOpts] = useState(null);
-
   const [cryptoWalletChallenge, setCryptoWalletChallenge] = useState(null);
   const [cryptoWalletAddress, setCryptoWalletAddress] = useState(null);
 
@@ -101,14 +98,7 @@ const WorkBench = ({ stytch, stytchUser }) => {
         throw err;
       });
   };
-
-  const dispatchLink = (link) => {
-    setIsLink(true);
-    setIsError(false);
-    setIsLoading(false);
-    setResult(link);
-  };
-
+  
   const sessionGetSync = () => {
     dispatch(stytch.session.getSync());
   };
@@ -229,44 +219,16 @@ const WorkBench = ({ stytch, stytchUser }) => {
     return dispatch(stytch.user.update(diff));
   };
 
-  const webauthnRegisterStart = async () => {
-    const { public_key_credential_creation_options } = await dispatch(
-      stytch.webauthn.registerStart()
-    );
-    setCredCreateOpts(public_key_credential_creation_options);
-  };
-  const webauthnRegister = async (e) => {
-    if (!wrCredCreateOpts) {
-      return dispatch(
-        Promise.reject(
-          new Error("No creation options loaded. Call registerStart first.")
-        )
-      );
-    }
-    await dispatch(stytch.webauthn.register(wrCredCreateOpts));
-    setCredCreateOpts(null);
+  const webauthnRegister = async () => {
+    await dispatch(stytch.webauthn.register());
   };
 
-  const webauthnAuthenticateStart = async () => {
-    const { public_key_credential_request_options } = await dispatch(
-      stytch.webauthn.authenticateStart()
-    );
-    setCredRequestOpts(public_key_credential_request_options);
-  };
   const webauthnAuthenticate = async () => {
-    if (!wrCredRequestOpts) {
-      return dispatch(
-        Promise.reject(
-          new Error("No creation options loaded. Call registerStart first.")
-        )
-      );
-    }
     await dispatch(
-      stytch.webauthn.authenticate(wrCredRequestOpts, {
+      stytch.webauthn.authenticate({
         session_duration_minutes: 60,
       })
     );
-    setCredRequestOpts(null);
   };
 
   const cryptoWalletsAuthenticateStart = async () => {
@@ -307,12 +269,11 @@ const WorkBench = ({ stytch, stytchUser }) => {
         session_duration_minutes: 60,
       })
     );
-    setCredRequestOpts(null);
   };
 
-  const getUrlForProvider = (provider) => () =>
-    dispatchLink(
-      stytch.oauth[provider].getUrl({
+  const startOAuth = (provider) => () =>
+    dispatch(
+      stytch.oauth[provider].start({
         signup_redirect_url: getCallbackURL("oauth"),
         login_redirect_url: getCallbackURL("oauth"),
       })
@@ -545,42 +506,9 @@ const WorkBench = ({ stytch, stytchUser }) => {
             </button>
           </form>
           <h3>WebAuthn</h3>
-          <div>
-            <label htmlFor="register_start_data">Register Data Loaded:</label>
-            <input
-              type="checkbox"
-              disabled
-              checked={Boolean(wrCredCreateOpts)}
-            />
-          </div>
-          <Button
-            name="stytch.webauthn.registerStart()"
-            onClick={webauthnRegisterStart}
-          />
+          <Button name="stytch.webauthn.register()" onClick={webauthnRegister} />
           <br />
-          <Button
-            name="stytch.webauthn.register()"
-            onClick={webauthnRegister}
-          />
-          <div>
-            <label htmlFor="register_start_data">
-              Authenticate Data Loaded:
-            </label>
-            <input
-              type="checkbox"
-              disabled
-              checked={Boolean(wrCredRequestOpts)}
-            />
-          </div>
-          <Button
-            name="stytch.webauthn.authenticateStart()"
-            onClick={webauthnAuthenticateStart}
-          />
-          <br />
-          <Button
-            name="stytch.webauthn.authenticate()"
-            onClick={webauthnAuthenticate}
-          />
+          <Button name="stytch.webauthn.authenticate()" onClick={webauthnAuthenticate} />
           <br />
           <h3>Crypto Wallets</h3>
           <div>
@@ -611,18 +539,15 @@ const WorkBench = ({ stytch, stytchUser }) => {
           <br />
           <h3>OAuth</h3>
           <Button
-            name="stytch.oauth.google.getUrl()"
-            onClick={getUrlForProvider("google")}
+            name="stytch.oauth.google.start()"
+            onClick={startOAuth("google")}
           />
           <br />
-          {/*<Button name="stytch.oauth.microsoft.getUrl()" onClick={getUrlForProvider('microsoft')}/><br/>*/}
-          {/*<Button name="stytch.oauth.facebook.getUrl()" onClick={getUrlForProvider('facebook')}/><br/>*/}
           <Button
-            name="stytch.oauth.github.getUrl()"
-            onClick={getUrlForProvider("github")}
+            name="stytch.oauth.github.start()"
+            onClick={startOAuth('github')}
           />
           <br />
-          {/*<Button name="stytch.oauth.apple.getUrl()" onClick={getUrlForProvider('apple')}/><br/>*/}
           <Button
             name="stytch.oauth.authenticate()"
             onClick={oauthAuthenticate}

--- a/src/pages/OAuth.js
+++ b/src/pages/OAuth.js
@@ -11,9 +11,9 @@ export const LinkOAuth = () => {
     signup_redirect_url: `${window.location.origin}/authenticate?type=oauth`,
   };
 
-  const googleUrl = stytch.oauth.google.getUrl(oauthOpts);
-  const facebookUrl = stytch.oauth.facebook.getUrl(oauthOpts);
-  const githubUrl = stytch.oauth.github.getUrl(oauthOpts);
+  const startGoogleOAuth = () => stytch.oauth.google.start(oauthOpts);
+  const startFacebookOAuth = () => stytch.oauth.facebook.start(oauthOpts);
+  const startGithubOAuth = () => stytch.oauth.github.start(oauthOpts);
 
   const googleProvider = user.providers.find(
     (provider) => provider.provider_type === "Google"
@@ -25,20 +25,18 @@ export const LinkOAuth = () => {
     (provider) => provider.provider_type === "Github"
   );
 
-  const renderProvider = (title, provider, url) => {
+  const renderProvider = (title, provider, startOAuth) => {
     if (provider) {
       return (
         <>
           You've previously linked {title}. Your {title} ID is{" "}
           <code>{provider.provider_subject}</code>.{" "}
-          <a href={url}>Log in again?</a>
+          <button onClick={startOAuth}>Log in again?</button>
         </>
       );
     }
     return (
-      <a href={url}>
-        <button>Link your {title} account.</button>
-      </a>
+      <button onClick={startOAuth}>Link your {title} account.</button>
     );
   };
 
@@ -58,11 +56,11 @@ export const LinkOAuth = () => {
         <a href={"https://stytch.com/docs/api/oauth-overview"}>docs.</a>
         <br />
         <br />
-        {renderProvider("Google", googleProvider, googleUrl)}
+        {renderProvider("Google", googleProvider, startGoogleOAuth)}
         <br />
-        {renderProvider("Facebook", fbProvider, facebookUrl)}
+        {renderProvider("Facebook", fbProvider, startFacebookOAuth)}
         <br />
-        {renderProvider("Github", githubProvider, githubUrl)}
+        {renderProvider("Github", githubProvider, startGithubOAuth)}
         <br />
         <br />
         <Link to={"/home"}>{"<-Back"}</Link>

--- a/src/pages/Webauthn.js
+++ b/src/pages/Webauthn.js
@@ -1,33 +1,15 @@
 import { useStytch, useStytchUser } from "@stytch/react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 const RegisterWebauthn = ({ setStatus, setError }) => {
   const stytch = useStytch();
-  const [credCreateOpts, setCredCreateOpts] = useState(null);
-
-  const preloadRegistrationData = useCallback(
-    () =>
-      stytch.webauthn
-        .registerStart()
-        .then((data) =>
-          setCredCreateOpts(data.public_key_credential_creation_options)
-        )
-        .catch((e) => setError(e)),
-    [stytch, setError]
-  );
-
-  useEffect(() => {
-    preloadRegistrationData();
-  }, [preloadRegistrationData]);
 
   const registerWebauthn = async () => {
     try {
       setStatus("Registering...");
-      await stytch.webauthn.register(credCreateOpts);
+      await stytch.webauthn.register();
       setStatus("Registration successful!");
-      setCredCreateOpts(null);
-      await preloadRegistrationData();
     } catch (e) {
       setError(e);
     }
@@ -38,7 +20,7 @@ const RegisterWebauthn = ({ setStatus, setError }) => {
       There are two steps during a WebAuthn authentication flow, registration
       and authentication. The first step handles registering a WebAuthn device
       to a user.&nbsp;&nbsp;&nbsp;
-      <button disabled={!credCreateOpts} onClick={registerWebauthn}>
+      <button onClick={registerWebauthn}>
         Register.
       </button>
     </>
@@ -47,32 +29,14 @@ const RegisterWebauthn = ({ setStatus, setError }) => {
 
 const AuthenticateWebauthn = ({ setStatus, setError }) => {
   const stytch = useStytch();
-  const [credRequestOpts, setCredRequestOpts] = useState(null);
-
-  const preloadAuthenticationData = useCallback(
-    () =>
-      stytch.webauthn
-        .authenticateStart()
-        .then((data) =>
-          setCredRequestOpts(data.public_key_credential_request_options)
-        )
-        .catch((e) => setError(e)),
-    [stytch, setError]
-  );
-
-  useEffect(() => {
-    preloadAuthenticationData();
-  }, [preloadAuthenticationData]);
 
   const authenticateWebauthn = async () => {
     try {
       setStatus("Authenticating...");
-      await stytch.webauthn.authenticate(credRequestOpts, {
+      await stytch.webauthn.authenticate({
         session_duration_minutes: 60,
       });
-      setCredRequestOpts(null);
       setStatus("Authentication successful!");
-      await preloadAuthenticationData();
     } catch (e) {
       setError(e);
     }
@@ -83,7 +47,7 @@ const AuthenticateWebauthn = ({ setStatus, setError }) => {
       After registration is complete, the WebAuthn device can be used to
       authenticate the active user, for MFA or Step-Up authentication.
       &nbsp;&nbsp;&nbsp;
-      <button disabled={!credRequestOpts} onClick={authenticateWebauthn}>
+      <button onClick={authenticateWebauthn}>
         Authenticate.
       </button>
     </>


### PR DESCRIPTION
Some of the methods in the SDK have been altered while migrating to the new SDK:
- `stytch.oauth.getUrl`
- `stytch.webauthn.registerStart` and `stytch.webauthn.authenticateStart`
- `stytch.user.deleteWebauthnRegistration`
- `stytch.user.deleteTOTP`

This PR tries to update the usage of these methods in the Workbench and other pages.